### PR TITLE
Fix analyzer warnings shown by the DartLang Atom plugin

### DIFF
--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -139,14 +139,14 @@ class Intl {
    * will be substituted in the message.
    *
    * The [message_str] is the string to be translated, which may be interpolated
-   * based on one or more variables. The [name] of the message must 
-   * match the enclosing function name. For methods, it can also be 
+   * based on one or more variables. The [name] of the message must
+   * match the enclosing function name. For methods, it can also be
    * className_methodName. So for a method hello in class Simple, the name
    * can be either "hello" or "Simple_hello". The name must also be globally
    * unique in the program, so the second form can make it easier to distinguish
    * messages with the same name but in different classes.
    * The [args] repeats the arguments of the enclosing
-   * function, [desc] provides a description of usage, 
+   * function, [desc] provides a description of usage,
    * [examples] is a Map of exmaples for each interpolated variable. For example
    *       hello(yourName) => Intl.message(
    *         "Hello, $yourName",
@@ -182,12 +182,6 @@ class Intl {
    * be the default.
    */
   String get locale => _locale;
-
-  /**
-   * Return true if the locale exists, or if it is null. The null case
-   * is interpreted to mean that we use the default locale.
-   */
-  static bool _localeExists(localeName) => DateFormat.localeExists(localeName);
 
   /**
    * Given [newLocale] return a locale that we have data for that is similar

--- a/lib/src/intl/date_format.dart
+++ b/lib/src/intl/date_format.dart
@@ -57,7 +57,7 @@ part of intl;
  * For each skeleton there is a named constructor that can be used to create it.
  * It's also possible to pass the skeleton as a string, but the constructor
  * is preferred.
- * 
+ *
  *      ICU Name                   Skeleton
  *      --------                   --------
  *      DAY                          d
@@ -115,11 +115,11 @@ part of intl;
  *
  * Explicit Pattern Syntax: Formats can also be specified with a pattern string.
  * This can be used for formats that don't have a skeleton available, but these
- * will not adapt to different locales. For example, in an explicit pattern the 
- * letters "H" and "h" are available for 24 hour and 12 hour time formats 
+ * will not adapt to different locales. For example, in an explicit pattern the
+ * letters "H" and "h" are available for 24 hour and 12 hour time formats
  * respectively. But there isn't a way in an explicit pattern to get the
  * behaviour of the "j" skeleton, which prints 24 hour or 12 hour time according
- * to the conventions of the locale, and also includes am/pm markers where 
+ * to the conventions of the locale, and also includes am/pm markers where
  * appropriate. So it is preferable to use the skeletons.
  *
  * The following characters are available in explicit patterns:
@@ -637,17 +637,6 @@ class DateFormat {
   DateSymbols get dateSymbols => dateTimeSymbols[_locale];
 
   /**
-   * Set the locale. If the locale can't be found, we also look up
-   * based on alternative versions, e.g. if we have no 'en_CA' we will
-   * look for 'en' as a fallback. It will also translate en-ca into en_CA.
-   * Null is also considered a valid value for [newLocale], indicating
-   * to use the default.
-   */
-  _setLocale(String newLocale) {
-    _locale = Intl.verifiedLocale(newLocale, localeExists);
-  }
-
-  /**
    * Return true if the locale exists, or if it is null. The null case
    * is interpreted to mean that we use the default locale.
    */
@@ -690,5 +679,6 @@ class DateFormat {
         return _fieldConstructors[i](match.group(0), this);
       }
     }
+    return null;
   }
 }

--- a/lib/src/intl/date_format_field.dart
+++ b/lib/src/intl/date_format_field.dart
@@ -476,7 +476,6 @@ class _DateFormatPatternField extends _DateFormatField {
   }
 
   String formatAmPm(DateTime date) {
-    var hours = date.hour;
     var index = (date.hour >= 12) && (date.hour < 24) ? 1 : 0;
     var ampm = symbols.AMPMS;
     return ampm[index];

--- a/lib/src/intl/number_format.dart
+++ b/lib/src/intl/number_format.dart
@@ -216,7 +216,6 @@ class NumberFormat {
     var exponent = (log(number) / log(10)).floor();
     var mantissa = number / pow(10.0, exponent);
 
-    var minIntDigits = minimumIntegerDigits;
     if (maximumIntegerDigits > 1 &&
         maximumIntegerDigits > minimumIntegerDigits) {
       // A repeating range is defined; adjust to it as follows.
@@ -228,7 +227,6 @@ class NumberFormat {
         mantissa *= 10;
         exponent--;
       }
-      minIntDigits = 1;
     } else {
       // No repeating range is defined, use minimum integer digits.
       if (minimumIntegerDigits < 1) {
@@ -399,9 +397,6 @@ class NumberFormat {
    */
   void _add(String x) {
     _buffer.write(x);
-  }
-  void _addCharCode(int x) {
-    _buffer.writeCharCode(x);
   }
   void _addZero() {
     _buffer.write(symbols.ZERO_DIGIT);

--- a/test/bidi_utils_test.dart
+++ b/test/bidi_utils_test.dart
@@ -314,12 +314,6 @@ main() {
     for (var i = 0; i < bidiText.length; i++) {
       var isRtlDir = Bidi.detectRtlDirectionality(bidiText[i].text,
           isHtml: bidiText[i].isHtml);
-      if (isRtlDir != bidiText[i].isRtl) {
-        var str = '"${bidiText[i].text} " should be '
-            '${bidiText[i].isRtl ? "rtl" : "ltr"} but detected as '
-            '${isRtlDir ? "rtl" : "ltr"}';
-        //alert(str);
-      }
       expect(bidiText[i].isRtl, isRtlDir);
     }
   });


### PR DESCRIPTION
Atom also removed some trailing newlines and I didn't fight it.

All of these _ methods are private to the library, thus removing them
should be safe.