### PR TITLE
tweak the formatting of the generated code

### DIFF
--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -147,7 +147,7 @@ void generateIndividualMessageFile(String basicLocale,
       .expand((translation) => translation.originalMessages)
       .map((original) =>
           '    "${original.name}" : ${_mapReference(original, locale)}');
-  result..write(entries.join(",\n"))..write("\n  };\n}");
+  result..write(entries.join(",\n"))..write("\n  };\n}\n");
 
   // To preserve compatibility, we don't use the canonical version of the locale
   // in the file name.
@@ -182,22 +182,20 @@ String _mapReference(MainMessage original, String locale) {
  * parameterized by [locale].
  */
 String prologue(String locale) => """
-/**
- * DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
- * This is a library that provides messages for a $locale locale. All the
- * messages from the main program should be duplicated here with the same
- * function name.
- */
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a $locale locale. All the messages
+// from the main program should be duplicated here with the same function name.
 
 library ${_libraryName(locale)};
+
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
 
 final messages = new MessageLookup();
 
 class MessageLookup extends MessageLookupByLibrary {
-
   get localeName => '$locale';
+
 """;
 
 /**
@@ -215,12 +213,12 @@ String generateMainImportFile() {
     output.write("as ${_libraryName(locale)};\n");
   }
   output.write("\n");
-  output.write("\nMap<String, Function> _deferredLibraries = {\n");
+  output.write("Map<String, Function> _deferredLibraries = {\n");
   for (var rawLocale in allLocales) {
     var locale = Intl.canonicalizedLocale(rawLocale);
     var loadOperation = (useDeferredLoading)
-        ? "  '$locale' : () => ${_libraryName(locale)}.loadLibrary(),\n"
-        : "  '$locale' : () => new Future.value(null),\n";
+        ? "  '$locale': () => ${_libraryName(locale)}.loadLibrary(),\n"
+        : "  '$locale': () => new Future.value(null),\n";
     output.write(loadOperation);
   }
   output.write("};\n");
@@ -229,7 +227,7 @@ String generateMainImportFile() {
   for (var rawLocale in allLocales) {
     var locale = Intl.canonicalizedLocale(rawLocale);
     output.write(
-        "    case '$locale' : return ${_libraryName(locale)}.messages;\n");
+        "    case '$locale':\n      return ${_libraryName(locale)}.messages;\n");
   }
   output.write(closing);
   return output.toString();
@@ -240,18 +238,17 @@ String generateMainImportFile() {
  * file.
  */
 var mainPrologue = """
-/**
- * DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
- * This is a library that looks up messages for specific locales by
- * delegating to the appropriate library.
- */
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by delegating
+// to the appropriate library.
 
 library messages_all;
 
 import 'dart:async';
+
+import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
 import 'package:$intlImportPath/src/intl_helpers.dart';
-import 'package:$intlImportPath/intl.dart';
 
 """;
 
@@ -259,11 +256,11 @@ import 'package:$intlImportPath/intl.dart';
  * Constant string used in [generateMainImportFile] as the end of the file.
  */
 const closing = """
-    default: return null;
+    default:\n      return null;
   }
 }
 
-/** User programs should call this before using [localeName] for messages.*/
+/** User programs should call this before using [localeName] for messages. */
 Future initializeMessages(String localeName) {
   initializeInternalMessageLookup(() => new CompositeMessageLookup());
   var lib = _deferredLibraries[Intl.canonicalizedLocale(localeName)];


### PR DESCRIPTION
This tweaks the ws of the generated code in order to reduce the number of formatting diffs (when run through dartfmt).

before:

```dart
/**
 * DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 * This is a library that provides messages for a en locale. All the
 * messages from the main program should be duplicated here with the same
 * function name.
 */

library messages_en;
import 'package:intl/intl.dart';
import 'package:intl/message_lookup_by_library.dart';

final messages = new MessageLookup();

class MessageLookup extends MessageLookupByLibrary {

  get localeName => 'en';
  static market() => "MARKET";

  static portfolio() => "PORTFOLIO";

  static title() => "Stocks";


  final messages = const {
    "market" : market,
    "portfolio" : portfolio,
    "title" : title
  };
}
```

after:

```dart
// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
// This is a library that provides messages for a en locale. All the messages
// from the main program should be duplicated here with the same function name.

library messages_en;

import 'package:intl/intl.dart';
import 'package:intl/message_lookup_by_library.dart';

final messages = new MessageLookup();

class MessageLookup extends MessageLookupByLibrary {
  get localeName => 'en';

  final messages = _notInlinedMessages(_notInlinedMessages);
  static _notInlinedMessages(_) => {
    "market" : MessageLookupByLibrary.simpleMessage("MARKET"),
    "portfolio" : MessageLookupByLibrary.simpleMessage("PORTFOLIO"),
    "title" : MessageLookupByLibrary.simpleMessage("Stocks")
  };
}
```

Note that the before generator was using a slightly older version of `intl`.