### PR TITLE
Improve robustness of DateFormat.parseLoose(); fixes #80 and #81.

### DIFF
--- a/lib/src/intl/date_format_field.dart
+++ b/lib/src/intl/date_format_field.dart
@@ -51,10 +51,18 @@ abstract class _DateFormatField {
   /// Parse a literal field. We accept either an exact match, or an arbitrary
   /// amount of whitespace.
   void parseLiteralLoose(_Stream input) {
-    var found = input.peek(width);
-    if (found == pattern) {
-      input.read(width);
+    _parseWhitespace(input);
+
+    var trimmedPattern = pattern.trim();
+    var found = input.peek(trimmedPattern.length);
+    if (found == trimmedPattern) {
+      input.read(trimmedPattern.length);
     }
+
+    _parseWhitespace(input);
+  }
+
+  void _parseWhitespace(_Stream input) {
     while (!input.atEnd() && input.peek().trim().isEmpty) {
       input.read();
     }
@@ -132,7 +140,7 @@ class _LoosePatternField extends _DateFormatPatternField {
 
   /// Parse a month name, case-insensitively, and set it in [dateFields].
   /// Assumes that [input] is lower case.
-  void parseMonth(input, dateFields) {
+  void parseMonth(_Stream input, dateFields) {
     if (width <= 2) {
       handleNumericField(input, dateFields.setMonth);
       return;
@@ -145,6 +153,7 @@ class _LoosePatternField extends _DateFormatPatternField {
         return;
       }
     }
+    throwFormatException(input);
   }
 
   /// Parse a standalone day name, case-insensitively.
@@ -167,11 +176,11 @@ class _LoosePatternField extends _DateFormatPatternField {
     }
   }
 
-  /// Parse a standalone month name, case-insensitively.
-  /// Assumes that input is lower case. Doesn't do anything
+  /// Parse a standalone month name, case-insensitively, and set it in
+  /// [dateFields]. Assumes that input is lower case.
   void parseStandaloneMonth(input, dateFields) {
     if (width <= 2) {
-      handleNumericField(input, (x) => x);
+      handleNumericField(input, dateFields.setMonth);
       return;
     }
     var possibilities = [
@@ -185,6 +194,7 @@ class _LoosePatternField extends _DateFormatPatternField {
         return;
       }
     }
+    throwFormatException(input);
   }
 
   /// Parse a day of the week name, case-insensitively.

--- a/lib/src/intl/date_format_helpers.dart
+++ b/lib/src/intl/date_format_helpers.dart
@@ -172,7 +172,7 @@ class _Stream {
 
   /// Assuming that the contents are characters, read as many digits as we
   /// can see and then return the corresponding integer. Advance the stream.
-  var digitMatcher = new RegExp(r'\d+');
+  var digitMatcher = new RegExp(r'^\d+');
   int nextInteger() {
     var string = digitMatcher.stringMatch(rest());
     if (string == null || string.isEmpty) return null;

--- a/test/date_time_loose_parsing_test.dart
+++ b/test/date_time_loose_parsing_test.dart
@@ -3,10 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Tests for the loose option when parsing dates and times, which accept
-/// mixed-case input and are able to skip missing delimiters. This is only
-/// tested in basic US locale, it's hard to define for others.
+/// mixed-case input and are able to skip missing delimiters. Such valid input
+/// is only tested in basic US locale, it's hard to define for others.
+/// Inputs which should fail because they're missing data (currently only the
+/// year) are tested in more locales.
 library date_time_loose_test;
 
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:unittest/unittest.dart';
 
@@ -34,6 +37,7 @@ main() {
     check("september 3, 2014");
     check("sEPTembER 3, 2014");
     check("seP 3, 2014");
+    check("Sep 3,2014");
   });
 
   test("Loose parsing yMMMd that parses strict", () {
@@ -45,12 +49,57 @@ main() {
     check("09 3 2014");
     check("09 00003    2014");
     check("09/    03/2014");
-    expect(() => format.parseLoose("09 / 03 / 2014"),
-        throwsA(new isInstanceOf<FormatException>()));
+    check("09 / 03 / 2014");
   });
 
   test("Loose parsing yMd that parses strict", () {
     expect(format.parseLoose("09/03/2014"), date);
     expect(format.parseLoose("09/3/2014"), date);
+  });
+
+  test("Loose parsing should handle standalone month format", () {
+    // This checks that LL actually sets the month.
+    // The appended whitespace and extra d pattern are present to trigger the
+    // loose parsing code path.
+    expect(new DateFormat('LL/d', 'en_US').parseLoose("05/ 2").month, 5);
+  });
+
+  group("Loose parsing with year formats", () {
+    test("should fail when year is omitted (en_US)", () {
+      expect(() => new DateFormat('yyyy-MM-dd').parseLoose("1/11"),
+          throwsFormatException);
+    });
+
+    test("should fail when year is omitted (ja)", () {
+      initializeDateFormatting('ja', null);
+      expect(() => new DateFormat.yMMMd("ja").parseLoose('12月12日'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMd("ja").parseLoose('12月12日'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMEd("ja").parseLoose('12月12日'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMMMEd("ja").parseLoose('12月12日'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMMMMd("ja").parseLoose('12月12日'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMMMMEEEEd("ja").parseLoose('12月12日'),
+          throwsFormatException);
+    });
+
+    test("should fail when year is omitted (hu)", () {
+      initializeDateFormatting('hu', null);
+      expect(() => new DateFormat.yMMMd("hu").parseLoose('3. 17.'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMd("hu").parseLoose('3. 17.'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMEd("hu").parseLoose('3. 17.'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMMMEd("hu").parseLoose('3. 17.'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMMMMd("hu").parseLoose('3. 17.'),
+          throwsFormatException);
+      expect(() => new DateFormat.yMMMMEEEEd("hu").parseLoose('3. 17.'),
+          throwsFormatException);
+    });
   });
 }


### PR DESCRIPTION
Slightly widens the scope of what parseLoose() will accept, while making the parsing more robust against cases where expected patterns are missing.

For example, year+month+day patterns will correctly throw a FormatException if no year exists in the input. Similarly, if the pattern specifies a month name, it must exist in the input.

Expected whitespace around delimiters can now be omitted, and whitespace can be added before delimiters.

The modification to the digit matching regexp fixes an issue where the stream would not be advanced all the way past a numeric string which was preceded by some padding. This caused digits or partial digits to be read twice in some circumstances.

Also fixed parseLoose() failing to return a value for the two-digit standalone month pattern (LL).
