### PR TITLE
Corrected command parameter syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This expects to receive a series of files, one per
 locale.
 
 ```
-pub run intl_translation:generate_from_arb --generated_file_prefix=<prefix>
+pub run intl_translation:generate_from_arb --generated-file-prefix=<prefix>
     <my_dart_files> <translated_ARB_files>
 ```
 


### PR DESCRIPTION
See https://github.com/dart-lang/intl_translation/blob/7db89811657334894cd222c10666e3f494b87a67/bin/generate_from_arb.dart#L57