### PR TITLE
make sure init date format and number format with a fallback locale

### DIFF
--- a/lib/src/intl/date_format.dart
+++ b/lib/src/intl/date_format.dart
@@ -244,7 +244,7 @@ class DateFormat {
     // confusion with the locale. A "fluent" interface with cascading on an
     // instance might work better? A list of patterns is also possible.
     _locale = Intl.verifiedLocale(locale, localeExists,
-        onFailure: (String _) => 'en_US');
+        onFailure: (String _) => 'en');
     addPattern(newPattern);
   }
 

--- a/lib/src/intl/date_format.dart
+++ b/lib/src/intl/date_format.dart
@@ -243,7 +243,8 @@ class DateFormat {
     // the constructor seems awkward, especially with the possibility of
     // confusion with the locale. A "fluent" interface with cascading on an
     // instance might work better? A list of patterns is also possible.
-    _locale = Intl.verifiedLocale(locale, localeExists);
+    _locale = Intl.verifiedLocale(locale, localeExists,
+        onFailure: (String _) => 'en_US');
     addPattern(newPattern);
   }
 

--- a/lib/src/intl/number_format.dart
+++ b/lib/src/intl/number_format.dart
@@ -494,7 +494,7 @@ class NumberFormat {
       int decimalDigits,
       bool isForCurrency: false})
       : _locale = Intl.verifiedLocale(locale, localeExists,
-            onFailure: (String _) => 'en_US'),
+            onFailure: (String _) => 'en'),
         _isForCurrency = isForCurrency {
     this._currencySymbol = currencySymbol;
     this._decimalDigits = decimalDigits;

--- a/lib/src/intl/number_format.dart
+++ b/lib/src/intl/number_format.dart
@@ -493,7 +493,8 @@ class NumberFormat {
       String computeCurrencySymbol(NumberFormat),
       int decimalDigits,
       bool isForCurrency: false})
-      : _locale = Intl.verifiedLocale(locale, localeExists),
+      : _locale = Intl.verifiedLocale(locale, localeExists,
+            onFailure: (String _) => 'en_US'),
         _isForCurrency = isForCurrency {
     this._currencySymbol = currencySymbol;
     this._decimalDigits = decimalDigits;


### PR DESCRIPTION
It's check `intl.DateFormat.localeExists` on `flutter_localizations/lib/src/material_localizations.dart`,

It's will direct `new intl.DateFormat` if no any locale exists, but date format and number format will throw `_throwLocaleError` if no any locale exists.

so that those two class should fallback if no any locale exists.