### PR TITLE
Updated example for the `message` method

### DIFF
--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -148,7 +148,7 @@ class Intl {
   ///         name: "hello",
   ///         args: [yourName],
   ///         desc: "Say hello",
-  ///         examples = const {"yourName": "Sparky"}.
+  ///         examples: const {"yourName": "Sparky"});
   ///
   /// The source code will be processed via the analyzer to extract out the
   /// message data, so only a subset of valid Dart code is accepted. In


### PR DESCRIPTION
The example of the `message` method has an invalid structure and does not compile when used.