### PR TITLE
Change default currency for pt locale to EUR

### DIFF
--- a/lib/number_symbols_data.dart
+++ b/lib/number_symbols_data.dart
@@ -1591,7 +1591,9 @@ Map<dynamic, dynamic> numberFormatSymbols = <String, NumberSymbols>{
       DECIMAL_PATTERN: '#,##0.###',
       SCIENTIFIC_PATTERN: '#E0',
       PERCENT_PATTERN: '#,##0%',
+      // MANUAL EDIT TO FIX PORTUGUESE CURRENCY PATTERN TO CONFRONT EUR PATTERN.
       CURRENCY_PATTERN: '#,##0.00\u00A0\u00A4',
+      // MANUAL EDIT TO FIX PORTUGUESE DEFAULT CURRENCY FROM BLN TO EUR.
       DEF_CURRENCY_CODE: 'EUR'),
   // Number formatting symbols for locale pt_BR.
   "pt_BR": new NumberSymbols(

--- a/lib/number_symbols_data.dart
+++ b/lib/number_symbols_data.dart
@@ -1593,7 +1593,7 @@ Map<dynamic, dynamic> numberFormatSymbols = <String, NumberSymbols>{
       PERCENT_PATTERN: '#,##0%',
       // MANUAL EDIT TO FIX PORTUGUESE CURRENCY PATTERN TO CONFRONT EUR PATTERN.
       CURRENCY_PATTERN: '#,##0.00\u00A0\u00A4',
-      // MANUAL EDIT TO FIX PORTUGUESE DEFAULT CURRENCY FROM BLN TO EUR.
+      // MANUAL EDIT TO FIX PORTUGUESE DEFAULT CURRENCY FROM BRL TO EUR.
       DEF_CURRENCY_CODE: 'EUR'),
   // Number formatting symbols for locale pt_BR.
   "pt_BR": new NumberSymbols(

--- a/lib/number_symbols_data.dart
+++ b/lib/number_symbols_data.dart
@@ -1591,8 +1591,8 @@ Map<dynamic, dynamic> numberFormatSymbols = <String, NumberSymbols>{
       DECIMAL_PATTERN: '#,##0.###',
       SCIENTIFIC_PATTERN: '#E0',
       PERCENT_PATTERN: '#,##0%',
-      CURRENCY_PATTERN: '\u00A4\u00A0#,##0.00',
-      DEF_CURRENCY_CODE: 'BRL'),
+      CURRENCY_PATTERN: '#,##0.00\u00A0\u00A4',
+      DEF_CURRENCY_CODE: 'EUR'),
   // Number formatting symbols for locale pt_BR.
   "pt_BR": new NumberSymbols(
       NAME: "pt_BR",


### PR DESCRIPTION
Having euro as a default currency for the Portuguese locale is a lot more convenient than a Brazilian dollar.

Closes #296 