### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/date_symbol_data_file.dart
+++ b/lib/date_symbol_data_file.dart
@@ -7,8 +7,6 @@
 
 library date_symbol_data_file;
 
-import 'dart:async';
-
 import 'package:path/path.dart' as path;
 
 import 'date_symbols.dart';

--- a/lib/date_symbol_data_http_request.dart
+++ b/lib/date_symbol_data_http_request.dart
@@ -6,8 +6,6 @@
 /// locale data via http requests to a web server..
 library date_symbol_data_http_request;
 
-import 'dart:async';
-
 import 'date_symbols.dart';
 import 'intl.dart';
 import 'src/data/dates/locale_list.dart';

--- a/lib/date_symbol_data_local.dart
+++ b/lib/date_symbol_data_local.dart
@@ -23,7 +23,6 @@ library date_symbol_data_local;
 import "date_symbols.dart";
 import "src/date_format_internal.dart";
 import "date_time_patterns.dart";
-import "dart:async";
 
 /// This should be called for at least one [locale] before any date
 /// formatting methods are called. It sets up the lookup for date

--- a/lib/intl_browser.dart
+++ b/lib/intl_browser.dart
@@ -9,7 +9,6 @@
 
 library intl_browser;
 
-import 'dart:async';
 import 'dart:html';
 import 'intl.dart';
 

--- a/lib/intl_standalone.dart
+++ b/lib/intl_standalone.dart
@@ -9,7 +9,6 @@
 
 library intl_standalone;
 
-import 'dart:async';
 import 'dart:io';
 import 'intl.dart';
 

--- a/lib/src/date_format_internal.dart
+++ b/lib/src/date_format_internal.dart
@@ -12,8 +12,6 @@
 
 library date_format_internal;
 
-import 'dart:async';
-
 import '../date_symbols.dart';
 import 'intl_helpers.dart';
 

--- a/lib/src/file_data_reader.dart
+++ b/lib/src/file_data_reader.dart
@@ -7,7 +7,6 @@
 
 library file_data_reader;
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart';

--- a/lib/src/intl_helpers.dart
+++ b/lib/src/intl_helpers.dart
@@ -7,7 +7,6 @@
 
 library intl_helpers;
 
-import 'dart:async';
 import 'package:intl/intl.dart';
 
 /// Type for the callback action when a message translation is not found.

--- a/lib/src/lazy_locale_data.dart
+++ b/lib/src/lazy_locale_data.dart
@@ -8,7 +8,6 @@
 
 library lazy_locale_data;
 
-import 'dart:async';
 import 'dart:convert';
 import 'intl_helpers.dart';
 


### PR DESCRIPTION
Since this version doesn't support Dart 2.0, these imports are no longer
necessary.