### PR TITLE
Depend on package:ffi release rather than git branch

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   clock: ^1.1.0-nullsafety.1
+  ffi: ^0.2.0-nullsafety.0
   path: ^1.8.0-nullsafety.1
 
 dev_dependencies:
@@ -20,9 +21,5 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.4
 
 dependency_overrides:
-  ffi:
-    git:
-      url: https://github.com/dart-lang/ffi
-      ref: null_safety
   fixnum:
     git: https://github.com/dart-lang/fixnum


### PR DESCRIPTION
I purged branches and then this broke. I think this should be the right release.