### PR TITLE
Skip a few more locales on the web

### DIFF
--- a/test/number_format_compact_icu_test.dart
+++ b/test/number_format_compact_icu_test.dart
@@ -23,19 +23,16 @@ main() {
     'bn',
   ];
 
-  runICUTests(systemIcuVersion: 63, skipLocales: problemLocales);
-}
-
-void runICUTests(
-    {int? systemIcuVersion, String? specialIcuLib, List<String>? skipLocales}) {
   if (!setupICU(
       systemIcuVersion: systemIcuVersion, specialIcuLibPath: specialIcuLib)) {
     return;
   }
 
-  print("Skipping problem locales $skipLocales.");
-  testdata35.compactNumberTestData
-      .removeWhere((k, v) => skipLocales!.contains(k));
+  void validate(String locale, List<List<String>> expected) {
+    validateShort(locale, expected, problemLocales);
+    validateLong(locale, expected, problemLocales);
+  }
+
   testdata35.compactNumberTestData.forEach(validate);
   more_testdata.cldr35CompactNumTests.forEach(validateFancy);
 
@@ -44,27 +41,27 @@ void runICUTests(
   });
 }
 
-void validate(String locale, List<List<String>> expected) {
-  validateShort(locale, expected);
-  validateLong(locale, expected);
-}
-
-void validateShort(String locale, List<List<String>> expected) {
+void validateShort(
+    String locale, List<List<String>> expected, List<String> skipLocales) {
+  var skip =
+      skipLocales.contains(locale) ? 'Skipping problem locale $locale' : false;
   test('Validate $locale SHORT', () {
     for (var data in expected) {
       var number = num.parse(data.first);
       expect(FormatWithUnumf(locale, 'compact-short', number), data[1]);
     }
-  });
+  }, skip: skip);
 }
 
 void validateLong(String locale, List<List<String>> expected) {
+  var skip =
+      skipLocales.contains(locale) ? 'Skipping problem locale $locale' : false;
   test('Validate $locale LONG', () {
     for (var data in expected) {
       var number = num.parse(data.first);
       expect(FormatWithUnumf(locale, 'compact-long', number), data[2]);
     }
-  });
+  }, skip: skip);
 }
 
 void validateFancy(more_testdata.CompactRoundingTestCase t) {

--- a/test/number_format_compact_test.dart
+++ b/test/number_format_compact_test.dart
@@ -210,10 +210,9 @@ void validate(String locale, List<List<String>> expected) {
 /// Check each bit of test data against the short compact format, both
 /// formatting and parsing.
 void validateShort(String locale, List<List<String>> expected) {
-  if (problemLocalesShort.contains(locale)) {
-    print("Skipping problem locale '$locale' for SHORT compact number tests");
-    return;
-  }
+  var skip = problemLocalesLong.contains(locale)
+      ? "Skipping problem locale '$locale' for SHORT compact number tests"
+      : false;
   var shortFormat = NumberFormat.compact(locale: locale);
   test('Validate $locale SHORT', () {
     for (var data in expected) {
@@ -223,21 +222,20 @@ void validateShort(String locale, List<List<String>> expected) {
       validateNumber(int64Number, shortFormat, data[1]);
       // TODO(alanknight): Make this work for MicroMoney
     }
-  });
+  }, skip: skip);
 }
 
 void validateLong(String locale, List<List<String>> expected) {
-  if (problemLocalesLong.contains(locale)) {
-    print("Skipping problem locale '$locale' for LONG compact number tests");
-    return;
-  }
+  var skip = problemLocalesLong.contains(locale)
+      ? "Skipping problem locale '$locale' for LONG compact number tests"
+      : false;
   var longFormat = NumberFormat.compactLong(locale: locale);
   test('Validate $locale LONG', () {
     for (var data in expected) {
       var number = num.parse(data.first);
       validateNumber(number, longFormat, data[2]);
     }
-  });
+  }, skip: skip);
 }
 
 void validateNumber(number, NumberFormat format, String expected) {

--- a/test/number_format_compact_test.dart
+++ b/test/number_format_compact_test.dart
@@ -139,7 +139,7 @@ void testCurrency(
 // case.
 // TODO(alanknight): Fix the problems, or at least figure out precisely where
 // the differences are.
-var problemLocalesShort = [
+var _skipLocalsShort = [
   'am', // AM Suffixes differ, not sure why.
   'ca', // For CA, CLDR rules are different. Jumps from 0000 to 00 prefix, so
   // 11 digits prints as 11900.
@@ -178,7 +178,7 @@ var problemLocalesShort = [
 ///
 //TODO(alanknight): Narrow these down to particular numbers. Often it's just
 // 999999.
-var problemLocalesLong = [
+var _skipLocalesLong = [
   'ar', 'ar_DZ', 'ar_EG',
   'be', 'bg', 'bs',
   'ca', 'cs', 'da', 'de', 'de_AT', 'de_CH', 'el', 'es', 'es_419', 'es_ES',
@@ -210,7 +210,7 @@ void validate(String locale, List<List<String>> expected) {
 /// Check each bit of test data against the short compact format, both
 /// formatting and parsing.
 void validateShort(String locale, List<List<String>> expected) {
-  var skip = problemLocalesLong.contains(locale)
+  var skip = _skipLocalsShort.contains(locale)
       ? "Skipping problem locale '$locale' for SHORT compact number tests"
       : false;
   var shortFormat = NumberFormat.compact(locale: locale);
@@ -226,7 +226,7 @@ void validateShort(String locale, List<List<String>> expected) {
 }
 
 void validateLong(String locale, List<List<String>> expected) {
-  var skip = problemLocalesLong.contains(locale)
+  var skip = _skipLocalesLong.contains(locale)
       ? "Skipping problem locale '$locale' for LONG compact number tests"
       : false;
   var longFormat = NumberFormat.compactLong(locale: locale);

--- a/test/number_format_compact_web_test.dart
+++ b/test/number_format_compact_web_test.dart
@@ -71,18 +71,19 @@ String ecmaFormatNumber(String locale, num number,
   return js.callMethod(number, 'toLocaleString', [locale, options]);
 }
 
-var ecmaProblemLocalesShort = [
+var _unsupportedChromeLocales = [
   // Not supported in Chrome:
   'af', 'az', 'be', 'br', 'bs', 'eu', 'ga', 'gl', 'gsw', 'haw', 'hy', 'is',
   'ka', 'kk', 'km', 'ky', 'ln', 'lo', 'mk', 'mn', 'mt', 'my', 'ne', 'no',
-  'no-NO', 'or', 'pa', 'si', 'sq', 'ur', 'uz', 'ps',
+  'no-NO', 'or', 'pa', 'si', 'sq', 'ur', 'uz', 'ps', 'chr', 'cy', 'tl', 'zu'
 ];
 
-var ecmaProblemLocalesLong = ecmaProblemLocalesShort +
-    [
-      // Short happens to match 'en', but actually not in Chrome:
-      'chr', 'cy', 'tl', 'zu'
-    ];
+var _skipLocalesShort = [
+  'am', 'bn', 'fa', // Some results change in chrome 88
+  ..._unsupportedChromeLocales
+];
+
+var _skipLocalesLong = _unsupportedChromeLocales;
 
 String fixLocale(String locale) {
   return locale.replaceAll('_', '-');
@@ -94,24 +95,22 @@ void validate(String locale, List<List<String>> expected) {
 }
 
 void validateShort(String locale, List<List<String>> expected) {
-  if (ecmaProblemLocalesShort.contains(locale)) {
-    print("Skipping problem locale '$locale' for SHORT compact number tests");
-    return;
-  }
+  var skip = _skipLocalesShort.contains(locale)
+      ? "Skipping problem locale '$locale' for SHORT compact number tests"
+      : false;
 
   test('Validate $locale SHORT', () {
     for (var data in expected) {
       var number = num.parse(data.first);
       expect(ecmaFormatNumber(locale, number, notation: 'compact'), data[1]);
     }
-  });
+  }, skip: skip);
 }
 
 void validateLong(String locale, List<List<String>> expected) {
-  if (ecmaProblemLocalesLong.contains(locale)) {
-    print("Skipping problem locale '$locale' for LONG compact number tests");
-    return;
-  }
+  var skip = _skipLocalesLong.contains(locale)
+      ? "Skipping problem locale '$locale' for LONG compact number tests"
+      : false;
 
   test('Validate $locale LONG', () {
     for (var data in expected) {
@@ -121,7 +120,7 @@ void validateLong(String locale, List<List<String>> expected) {
               notation: 'compact', compactDisplay: 'long'),
           data[2]);
     }
-  });
+  }, skip: skip);
 }
 
 void validateMore(more_testdata.CompactRoundingTestCase t) {


### PR DESCRIPTION
The update to chrome 88 changes some number formatting results. While
there is version skew between the chrome used internally and externally
for testing, skip these tests.

Improve the pattern for skipping test from using `print` as the only
signal, and omitting the test entirely, to using the `skip` argument
provided by the test runner. This allows skipped tests to be surfaced
correctly in the results.