### PR TITLE
Added tryParse to NumberFormat

### DIFF
--- a/lib/src/intl/number_format.dart
+++ b/lib/src/intl/number_format.dart
@@ -437,8 +437,18 @@ class NumberFormat {
   }
 
   /// Parse the number represented by the string. If it's not
-  /// parseable, throws a [FormatException].
+  /// parsable, throws a [FormatException].
   num parse(String text) => NumberParser(this, text).value!;
+
+  /// Parse the number represented by the string. If it's not
+  /// parsable, returns null.
+  num? tryParse(String text) {
+    try {
+      return NumberParser(this, text).value!;
+    } on FormatException {
+      return null;
+    }
+  }
 
   /// Format the main part of the number in the form dictated by the pattern.
   void _formatNumber(number) {

--- a/test/number_format_test_core.dart
+++ b/test/number_format_test_core.dart
@@ -307,12 +307,17 @@ void runTests(Map<String, num> allTestNumbers) {
     expect(f.format(0.12), '+12%');
   });
 
-  test('Unparseable', () {
+  test('Unparsable', () {
     var format = NumberFormat.currency();
     expect(() => format.parse('abcdefg'), throwsFormatException);
     expect(() => format.parse(''), throwsFormatException);
     expect(() => format.parse('1.0zzz'), throwsFormatException);
     expect(() => format.parse('-∞+1'), throwsFormatException);
+
+    expect(format.tryParse('abcdefg'), isNull);
+    expect(format.tryParse(''), isNull);
+    expect(format.tryParse('1.0zzz'), isNull);
+    expect(format.tryParse('-∞+1'), isNull);
   });
 
   var digitsCheck = {


### PR DESCRIPTION
Add `tryParse` to `NumberFormat`. This allows to parse number when uncertain if the input is correct (like user input):

```dart
final formatter = NumberFormat.decimalPattern(locale);
final value = formatter.tryParse(userInput) ?? double.nan;
```

instead of:

```dart
final formatter = NumberFormat.decimalPattern(locale);
num value;
try {
  value = formatter.parse(userInput);
} on FormatException {
  value = double.nan;
} 
```

This also matches the native dart parsing API: `num.parse` and `num.tryParse` (for `int` and `double` the same).