### PR TITLE
Remove non-nullable as experiment, require SDK 2.12.0 to enable it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.17.1-dev
 
 * Add optional parameter to `NumberFormat.compact()` to provide custom pattern.
+* Require Dart SDK `2.12.0`, with null safety.
 
 ## 0.17.0
  * Migrate to null safety.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,6 @@ errors:
 linter:
   rules:
     - always_declare_return_types
-    - avoid_classes_with_only_static_members
     - avoid_empty_else
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,4 @@
 analyzer:
-  enable-experiment:
-  - non-nullable
-
   language:
     strict-raw-types: true
 

--- a/lib/intl_standalone.dart
+++ b/lib/intl_standalone.dart
@@ -20,7 +20,7 @@ import 'intl.dart';
 /// Find the system locale, accessed via the appropriate system APIs, and
 /// set it as the default for internationalization operations in
 /// the [Intl.systemLocale] variable.
-Future<String> findSystemLocale() {
+Future<String?> findSystemLocale() {
   try {
     Intl.systemLocale = Intl.canonicalizedLocale(Platform.localeName);
   } catch (e) {

--- a/lib/message_format.dart
+++ b/lib/message_format.dart
@@ -253,8 +253,6 @@ class MessageFormat {
       var patternValue = currentPattern._value;
       var patternType = currentPattern._type;
 
-      _checkAndThrow(patternType is _BlockType,
-          'The type should be a block type: $patternType');
       switch (patternType) {
         case _BlockType.string:
           result.add(patternValue as String);
@@ -410,7 +408,6 @@ class MessageFormat {
     var pluralResult = Queue<String>();
     _formatBlock(option!, namedParameters, ignorePound, pluralResult);
     var plural = pluralResult.join('');
-    _checkAndThrow(plural is String, 'Empty block in plural.');
     if (ignorePound) {
       result.add(plural);
     } else {
@@ -562,8 +559,6 @@ class MessageFormat {
       if (_ElementType.string == thePart._type) {
         block = _BlockTypeAndVal(_BlockType.string, thePart._value);
       } else if (_ElementType.block == thePart._type) {
-        _checkAndThrow(thePart._value is String,
-            'The value should be a string: ${thePart._value}');
         var blockType = _parseBlockType(thePart._value);
 
         switch (blockType) {
@@ -614,7 +609,6 @@ class MessageFormat {
     var pos = 0;
     while (pos < parts.length) {
       var thePart = parts.elementAt(pos);
-      _checkAndThrow(thePart._value is String, 'Missing select key element.');
       var key = thePart._value;
 
       pos++;
@@ -664,7 +658,6 @@ class MessageFormat {
     var pos = 0;
     while (pos < parts.length) {
       var thePart = parts.elementAt(pos);
-      _checkAndThrow(thePart._value is String, 'Missing plural key element.');
       var key = thePart._value;
 
       pos++;
@@ -722,7 +715,6 @@ class MessageFormat {
     var pos = 0;
     while (pos < parts.length) {
       var thePart = parts.elementAt(pos);
-      _checkAndThrow(thePart._value is String, 'Missing ordinal key element.');
       var key = thePart._value;
 
       pos++;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
   internationalization issues.
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   clock: ^1.1.0


### PR DESCRIPTION
This causes issues in https://dart-review.googlesource.com/c/sdk/+/224520, although maybe we just need a slightly newer version pulled into the SDK. But we should enable actual null safety anyway.