### PR TITLE
various linting improvements for the repo

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,91 +1,12 @@
+include: package:lints/recommended.yaml
+
 analyzer:
   language:
     strict-raw-types: true
 
-  exclude:
-     - test/number_format_compact_icu_test.dart # TODO(240): Update for FFI changes
-
-errors:
-    dead_code: error
-    missing_required_param: error
-    override_on_non_overriding_method: error
-    unused_element: error
-    unused_import: error
-    unused_local_variable: error
-
 linter:
   rules:
-    - always_declare_return_types
-    - avoid_empty_else
-    - avoid_function_literals_in_foreach_calls
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_relative_lib_imports
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_as_parameter_names
-    - avoid_unused_constructor_parameters
-    - await_only_futures
-    - camel_case_types
-    - cancel_subscriptions
-    - constant_identifier_names
-    - control_flow_in_finally
-    - curly_braces_in_flow_control_structures
-    - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
-    - empty_statements
-    - file_names
-    - hash_and_equals
-    - implementation_imports
-    - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
-    - list_remove_unrelated_type
-    - literal_only_boolean_expressions
-    - no_duplicate_case_values
-    - non_constant_identifier_names
-    - null_closures
-    - omit_local_variable_types
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    - prefer_adjacent_string_concatenation
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_final_fields
-    - prefer_generic_function_type_aliases
-    - prefer_initializing_formals
-    - prefer_interpolation_to_compose_strings
-    - prefer_iterable_whereType
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_null_aware_operators
-    - prefer_typing_uninitialized_variables
-    - recursive_getters
-    - slash_for_doc_comments
-    - test_types_in_equals
-    - throw_in_finally
-    - type_init_formals
-    - unawaited_futures
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_getters_setters
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_parenthesis
-    - unnecessary_statements
-    - unnecessary_this
-    - unrelated_type_equality_checks
-    - use_function_type_syntax_for_parameters
-    - use_rethrow_when_possible
-    - valid_regexps
-    - void_checks
+    - always_declare_return_types: true
+    - avoid_dynamic_calls: true
+    - directives_ordering: true
+    - sort_pub_dependencies: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,8 @@ include: package:lints/recommended.yaml
 analyzer:
   language:
     strict-raw-types: true
+  errors:
+    deprecated_member_use_from_same_package: ignore
 
 linter:
   rules:

--- a/lib/date_symbols.dart
+++ b/lib/date_symbols.dart
@@ -136,34 +136,35 @@ class DateSymbols {
   // TODO(alanknight): Replace this with use of a more general serialization
   // facility once one is available. Issue 4926.
   factory DateSymbols.deserializeFromMap(Map<dynamic, dynamic> map) {
-    List<String> _getStringList(String name) => List<String>.from(map[name]);
+    List<String> getStringList(String name) => List<String>.from(map[name]);
+
     return DateSymbols(
       NAME: map['NAME'],
-      ERAS: _getStringList('ERAS'),
-      ERANAMES: _getStringList('ERANAMES'),
-      NARROWMONTHS: _getStringList('NARROWMONTHS'),
-      STANDALONENARROWMONTHS: _getStringList('STANDALONENARROWMONTHS'),
-      MONTHS: _getStringList('MONTHS'),
-      STANDALONEMONTHS: _getStringList('STANDALONEMONTHS'),
-      SHORTMONTHS: _getStringList('SHORTMONTHS'),
-      STANDALONESHORTMONTHS: _getStringList('STANDALONESHORTMONTHS'),
-      WEEKDAYS: _getStringList('WEEKDAYS'),
-      STANDALONEWEEKDAYS: _getStringList('STANDALONEWEEKDAYS'),
-      SHORTWEEKDAYS: _getStringList('SHORTWEEKDAYS'),
-      STANDALONESHORTWEEKDAYS: _getStringList('STANDALONESHORTWEEKDAYS'),
-      NARROWWEEKDAYS: _getStringList('NARROWWEEKDAYS'),
-      STANDALONENARROWWEEKDAYS: _getStringList('STANDALONENARROWWEEKDAYS'),
-      SHORTQUARTERS: _getStringList('SHORTQUARTERS'),
-      QUARTERS: _getStringList('QUARTERS'),
-      AMPMS: _getStringList('AMPMS'),
+      ERAS: getStringList('ERAS'),
+      ERANAMES: getStringList('ERANAMES'),
+      NARROWMONTHS: getStringList('NARROWMONTHS'),
+      STANDALONENARROWMONTHS: getStringList('STANDALONENARROWMONTHS'),
+      MONTHS: getStringList('MONTHS'),
+      STANDALONEMONTHS: getStringList('STANDALONEMONTHS'),
+      SHORTMONTHS: getStringList('SHORTMONTHS'),
+      STANDALONESHORTMONTHS: getStringList('STANDALONESHORTMONTHS'),
+      WEEKDAYS: getStringList('WEEKDAYS'),
+      STANDALONEWEEKDAYS: getStringList('STANDALONEWEEKDAYS'),
+      SHORTWEEKDAYS: getStringList('SHORTWEEKDAYS'),
+      STANDALONESHORTWEEKDAYS: getStringList('STANDALONESHORTWEEKDAYS'),
+      NARROWWEEKDAYS: getStringList('NARROWWEEKDAYS'),
+      STANDALONENARROWWEEKDAYS: getStringList('STANDALONENARROWWEEKDAYS'),
+      SHORTQUARTERS: getStringList('SHORTQUARTERS'),
+      QUARTERS: getStringList('QUARTERS'),
+      AMPMS: getStringList('AMPMS'),
       ZERODIGIT: map['ZERODIGIT'],
-      DATEFORMATS: _getStringList('DATEFORMATS'),
-      TIMEFORMATS: _getStringList('TIMEFORMATS'),
+      DATEFORMATS: getStringList('DATEFORMATS'),
+      TIMEFORMATS: getStringList('TIMEFORMATS'),
       AVAILABLEFORMATS: Map<String, String>.from(map['AVAILABLEFORMATS'] ?? {}),
       FIRSTDAYOFWEEK: map['FIRSTDAYOFWEEK'],
       WEEKENDRANGE: List<int>.from(map['WEEKENDRANGE']),
       FIRSTWEEKCUTOFFDAY: map['FIRSTWEEKCUTOFFDAY'],
-      DATETIMEFORMATS: _getStringList('DATETIMEFORMATS'),
+      DATETIMEFORMATS: getStringList('DATETIMEFORMATS'),
     );
   }
 

--- a/lib/date_symbols.dart
+++ b/lib/date_symbols.dart
@@ -205,6 +205,7 @@ class DateSymbols {
         'DATETIMEFORMATS': DATETIMEFORMATS,
       };
 
+  @override
   String toString() => NAME;
 }
 

--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -100,8 +100,7 @@ class Intl {
   /// locale to be used, otherwise, we will attempt to infer it (acceptable if
   /// Dart is running on the client, we can infer from the browser/client
   /// preferences).
-  Intl([String? aLocale])
-      : _locale = aLocale ?? getCurrentLocale();
+  Intl([String? aLocale]) : _locale = aLocale ?? getCurrentLocale();
 
   /// Use this for a message that will be translated for different locales. The
   /// expected usage is that this is inside an enclosing function that only

--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -101,7 +101,7 @@ class Intl {
   /// Dart is running on the client, we can infer from the browser/client
   /// preferences).
   Intl([String? aLocale])
-      : _locale = aLocale != null ? aLocale : getCurrentLocale();
+      : _locale = aLocale ?? getCurrentLocale();
 
   /// Use this for a message that will be translated for different locales. The
   /// expected usage is that this is inside an enclosing function that only
@@ -423,9 +423,9 @@ class Intl {
     ArgumentError.checkNotNull(other, 'other');
     switch (targetGender) {
       case 'female':
-        return female == null ? other : female;
+        return female ?? other;
       case 'male':
-        return male == null ? other : male;
+        return male ?? other;
       default:
         return other;
     }
@@ -532,6 +532,7 @@ class Intl {
     return defaultLocale ??= systemLocale;
   }
 
+  @override
   String toString() => 'Intl($locale)';
 }
 

--- a/lib/message_format.dart
+++ b/lib/message_format.dart
@@ -808,12 +808,12 @@ class _TypeAndVal<T, V> {
 enum _ElementType { string, block }
 
 class _ElementTypeAndVal extends _TypeAndVal<_ElementType, String> {
-  _ElementTypeAndVal(var _type, var _value) : super(_type, _value);
+  _ElementTypeAndVal(var type, var value) : super(type, value);
 }
 
 /// Block type.
 enum _BlockType { plural, ordinal, select, simple, string, unknown }
 
 class _BlockTypeAndVal extends _TypeAndVal<_BlockType, Object> {
-  _BlockTypeAndVal(var _type, var _value) : super(_type, _value);
+  _BlockTypeAndVal(var type, var value) : super(type, value);
 }

--- a/lib/message_lookup_by_library.dart
+++ b/lib/message_lookup_by_library.dart
@@ -19,7 +19,7 @@ import 'package:intl/src/intl_helpers.dart';
 /// of individual [MessageLookupByLibrary] instances.
 class CompositeMessageLookup implements MessageLookup {
   /// A map from locale names to the corresponding lookups.
-  Map<String, MessageLookupByLibrary> availableMessages = Map();
+  Map<String, MessageLookupByLibrary> availableMessages = {};
 
   /// Return true if we have a message lookup for [localeName].
   bool localeExists(localeName) => availableMessages.containsKey(localeName);
@@ -36,6 +36,7 @@ class CompositeMessageLookup implements MessageLookup {
   /// Look up the message with the given [name] and [locale] and return the
   /// translated version with the values in [args] interpolated.  If nothing is
   /// found, return the result of [ifAbsent] or [messageText].
+  @override
   String? lookupMessage(String? messageText, String? locale, String? name,
       List<Object>? args, String? meaning,
       {MessageIfAbsent? ifAbsent}) {
@@ -65,6 +66,7 @@ class CompositeMessageLookup implements MessageLookup {
   /// If we do not already have a locale for [localeName] then
   /// [findLocale] will be called and the result stored as the lookup
   /// mechanism for that locale.
+  @override
   void addLocale(String localeName, Function findLocale) {
     if (localeExists(localeName)) return;
     var canonical = Intl.canonicalizedLocale(localeName);
@@ -129,6 +131,7 @@ abstract class MessageLookupByLibrary {
   /// Subclasses should override this to return their locale, e.g. 'en_US'
   String get localeName;
 
+  @override
   String toString() => localeName;
 
   /// Return a function that returns the given string.

--- a/lib/number_symbols.dart
+++ b/lib/number_symbols.dart
@@ -46,6 +46,7 @@ class NumberSymbols {
       required this.CURRENCY_PATTERN,
       required this.DEF_CURRENCY_CODE});
 
+  @override
   String toString() => NAME;
 }
 

--- a/lib/src/data/dates/locale_list.dart
+++ b/lib/src/data/dates/locale_list.dart
@@ -117,5 +117,5 @@ final availableLocalesForDateFormatting = const [
   'zh_CN',
   'zh_HK',
   'zh_TW',
-  'zu'
+  'zu',
 ];

--- a/lib/src/file_data_reader.dart
+++ b/lib/src/file_data_reader.dart
@@ -19,6 +19,7 @@ class FileDataReader implements LocaleDataReader {
   FileDataReader(this.path);
 
   /// Read the locale data found for [locale] on our [path].
+  @override
   Future<String> read(String locale) {
     var file = File(join(path, '$locale.json'));
     return file.readAsString();

--- a/lib/src/global_state.dart
+++ b/lib/src/global_state.dart
@@ -10,7 +10,7 @@ set defaultLocale(String? newLocale) {
 
 String? get defaultLocale {
   var zoneLocale = Zone.current[#Intl.locale] as String?;
-  return zoneLocale == null ? _defaultLocale : zoneLocale;
+  return zoneLocale ?? _defaultLocale;
 }
 
 String getCurrentLocale() {

--- a/lib/src/http_request_data_reader.dart
+++ b/lib/src/http_request_data_reader.dart
@@ -16,6 +16,7 @@ class HttpRequestDataReader implements LocaleDataReader {
   String url;
   HttpRequestDataReader(this.url);
 
+  @override
   Future<String> read(String locale) {
     var request = HttpRequest();
     request.timeout = 5000;

--- a/lib/src/intl/bidi.dart
+++ b/lib/src/intl/bidi.dart
@@ -202,7 +202,7 @@ class Bidi {
   /// If [isRtlContext] is true, then we explicitly want to wrap in a span of
   /// RTL directionality, regardless of the estimated directionality.
   static String guardBracketInHtml(String str, [bool? isRtlContext]) {
-    var useRtl = isRtlContext == null ? hasAnyRtl(str) : isRtlContext;
+    var useRtl = isRtlContext ?? hasAnyRtl(str);
     var matchingBrackets =
         RegExp(r'(\(.*?\)+)|(\[.*?\]+)|(\{.*?\}+)|(&lt;.*?(&gt;)+)');
     return _guardBracketHelper(str, matchingBrackets,
@@ -216,7 +216,7 @@ class Bidi {
   /// explicitly want to wrap in a span of RTL directionality, regardless of the
   /// estimated directionality.
   static String guardBracketInText(String str, [bool? isRtlContext]) {
-    var useRtl = isRtlContext == null ? hasAnyRtl(str) : isRtlContext;
+    var useRtl = isRtlContext ?? hasAnyRtl(str);
     var mark = useRtl ? RLM : LRM;
     return _guardBracketHelper(
         str, RegExp(r'(\(.*?\)+)|(\[.*?\]+)|(\{.*?\}+)|(<.*?>+)'), mark, mark);

--- a/lib/src/intl/compact_number_format.dart
+++ b/lib/src/intl/compact_number_format.dart
@@ -114,9 +114,12 @@ class _CompactStyleWithNegative extends _CompactStyleBase {
   _CompactStyleWithNegative(this.positiveStyle, this.negativeStyle);
   final _CompactStyle positiveStyle;
   final _CompactStyle negativeStyle;
+  @override
   _CompactStyle styleForNumber(number, _CompactNumberFormat format) =>
       number < 0 ? negativeStyle : positiveStyle;
+  @override
   int get divisor => positiveStyle.divisor;
+  @override
   List<_CompactStyle> get allStyles => [positiveStyle, negativeStyle];
 }
 
@@ -148,6 +151,7 @@ class _CompactStyle extends _CompactStyleBase {
 
   /// What should we divide the number by in order to print. Normally is either
   /// 10^normalizedExponent or 1 if we shouldn't divide at all.
+  @override
   int divisor;
 
   // Prefixes / suffixes.
@@ -167,7 +171,9 @@ class _CompactStyle extends _CompactStyleBase {
   /// for a particular currency (e.g. two for USD, zero for JPY)
   bool get isFallback => pattern == null || pattern == '0';
 
+  @override
   _CompactStyle styleForNumber(number, _CompactNumberFormat format) => this;
+  @override
   List<_CompactStyle> get allStyles => [this];
 
   static final _regex = RegExp('([^0]*)(0+)(.*)');
@@ -395,15 +401,20 @@ class _CompactNumberFormat extends NumberFormat {
   _CompactStyle? _style;
 
   // We delegate prefixes to current _style.
+  @override
   String get positivePrefix =>
       _style!.isFallback ? super.positivePrefix : _style!.positivePrefix;
+  @override
   String get negativePrefix =>
       _style!.isFallback ? super.negativePrefix : _style!.negativePrefix;
+  @override
   String get positiveSuffix =>
       _style!.isFallback ? super.positiveSuffix : _style!.positiveSuffix;
+  @override
   String get negativeSuffix =>
       _style!.isFallback ? super.negativeSuffix : _style!.negativeSuffix;
 
+  @override
   String format(number) {
     var style = _styleFor(number);
     _style = style;
@@ -463,7 +474,7 @@ class _CompactNumberFormat extends NumberFormat {
     var digitLength = NumberFormat.numberOfIntegerDigits(number);
     var divisor = 1; // Default.
 
-    var updateRounding = () {
+    updateRounding() {
       var fractionDigits = maximumFractionDigits;
       if (significantDigitsInUse) {
         var divisorLength = NumberFormat.numberOfIntegerDigits(divisor);
@@ -485,7 +496,7 @@ class _CompactNumberFormat extends NumberFormat {
           divisor /
           fractionMultiplier;
       digitLength = NumberFormat.numberOfIntegerDigits(rounded);
-    };
+    }
 
     updateRounding();
 
@@ -517,6 +528,7 @@ class _CompactNumberFormat extends NumberFormat {
         .replaceAll('\u2212', '-'); // MINUS SIGN.
   }
 
+  @override
   num parse(final String inputText) {
     for (var style in [_defaultCompactStyle, ..._stylesForSearching]) {
       _style = style;

--- a/lib/src/intl/compact_number_format.dart
+++ b/lib/src/intl/compact_number_format.dart
@@ -474,7 +474,7 @@ class _CompactNumberFormat extends NumberFormat {
     var digitLength = NumberFormat.numberOfIntegerDigits(number);
     var divisor = 1; // Default.
 
-    updateRounding() {
+    void updateRounding() {
       var fractionDigits = maximumFractionDigits;
       if (significantDigitsInUse) {
         var divisorLength = NumberFormat.numberOfIntegerDigits(divisor);

--- a/lib/src/intl/date_format.dart
+++ b/lib/src/intl/date_format.dart
@@ -5,6 +5,7 @@
 import 'package:intl/date_symbols.dart';
 import 'package:intl/src/date_format_internal.dart';
 import 'package:intl/src/intl_helpers.dart' as helpers;
+import 'package:meta/meta.dart';
 
 import 'constants.dart' as constants;
 import 'date_builder.dart';
@@ -278,6 +279,9 @@ class DateFormat {
   /// There can be rare and erratic errors in DateTime creation in both
   /// JavaScript and the Dart VM, and this allows us to test ways of
   /// compensating for them.
+  @visibleForTesting
+  @Deprecated('clients should not depend on this internal field')
+  // ignore: library_private_types_in_public_api
   _DateTimeConstructor dateTimeConstructor = (int year, int month, int day,
       int hour24, int minute, int second, int fractionalSecond, bool utc) {
     if (utc) {
@@ -842,6 +846,9 @@ class DateFormat {
           ];
 
   /// Parse the template pattern and return a list of field objects.
+  @visibleForTesting
+  @Deprecated('clients should not depend on this internal method')
+  // ignore: library_private_types_in_public_api
   List<_DateFormatField> parsePattern(String pattern) {
     return _parsePatternHelper(pattern).reversed.toList();
   }

--- a/lib/src/intl/date_format_field.dart
+++ b/lib/src/intl/date_format_field.dart
@@ -31,6 +31,7 @@ abstract class _DateFormatField {
 
   String fullPattern() => pattern;
 
+  @override
   String toString() => pattern;
 
   /// Format date according to our specification and return the result.
@@ -95,10 +96,12 @@ class _DateFormatLiteralField extends _DateFormatField {
   _DateFormatLiteralField(String pattern, DateFormat parent)
       : super(pattern, parent);
 
+  @override
   void parse(IntlStream input, DateBuilder dateFields) {
     parseLiteral(input);
   }
 
+  @override
   void parseLoose(IntlStream input, DateBuilder dateFields) =>
       parseLiteralLoose(input);
 }
@@ -108,16 +111,19 @@ class _DateFormatLiteralField extends _DateFormatField {
 class _DateFormatQuotedField extends _DateFormatField {
   final String _fullPattern;
 
+  @override
   String fullPattern() => _fullPattern;
 
   _DateFormatQuotedField(String pattern, DateFormat parent)
       : _fullPattern = pattern,
         super(_patchQuotes(pattern), parent);
 
+  @override
   void parse(IntlStream input, DateBuilder dateFields) {
     parseLiteral(input);
   }
 
+  @override
   void parseLoose(IntlStream input, DateBuilder dateFields) =>
       parseLiteralLoose(input);
 
@@ -143,6 +149,7 @@ class _LoosePatternField extends _DateFormatPatternField {
 
   /// Parse from a list of possibilities, but case-insensitively.
   /// Assumes that input is lower case.
+  @override
   int parseEnumeratedString(IntlStream input, List<String> possibilities) {
     var lowercasePossibilities =
         possibilities.map((x) => x.toLowerCase()).toList();
@@ -155,6 +162,7 @@ class _LoosePatternField extends _DateFormatPatternField {
 
   /// Parse a month name, case-insensitively, and set it in [dateFields].
   /// Assumes that [input] is lower case.
+  @override
   void parseMonth(input, dateFields) {
     if (width <= 2) {
       handleNumericField(input, dateFields.setMonth);
@@ -173,6 +181,7 @@ class _LoosePatternField extends _DateFormatPatternField {
 
   /// Parse a standalone day name, case-insensitively.
   /// Assumes that input is lower case. Doesn't do anything
+  @override
   void parseStandaloneDay(input) {
     // This is ignored, but we still have to skip over it the correct amount.
     if (width <= 2) {
@@ -193,6 +202,7 @@ class _LoosePatternField extends _DateFormatPatternField {
 
   /// Parse a standalone month name, case-insensitively, and set it in
   /// [dateFields]. Assumes that input is lower case.
+  @override
   void parseStandaloneMonth(input, dateFields) {
     if (width <= 2) {
       handleNumericField(input, dateFields.setMonth);
@@ -214,6 +224,7 @@ class _LoosePatternField extends _DateFormatPatternField {
 
   /// Parse a day of the week name, case-insensitively.
   /// Assumes that input is lower case. Doesn't do anything
+  @override
   void parseDayOfWeek(IntlStream input) {
     // This is IGNORED, but we still have to skip over it the correct amount.
     if (width <= 2) {
@@ -239,12 +250,14 @@ class _DateFormatPatternField extends _DateFormatField {
   _DateFormatPatternField(pattern, parent) : super(pattern, parent);
 
   /// Format date according to our specification and return the result.
+  @override
   String format(DateTime date) {
     return formatField(date);
   }
 
   /// Parse the date according to our specification and put the result
   /// into the correct place in dateFields.
+  @override
   void parse(IntlStream input, DateBuilder dateFields) {
     parseField(input, dateFields);
   }
@@ -252,6 +265,7 @@ class _DateFormatPatternField extends _DateFormatField {
   /// Parse the date according to our specification and put the result
   /// into the correct place in dateFields. Allow looser parsing, accepting
   /// case-insensitive input and skipped delimiters.
+  @override
   void parseLoose(IntlStream input, DateBuilder dateFields) {
     _LoosePatternField(pattern, parent).parse(input, dateFields);
   }
@@ -265,6 +279,7 @@ class _DateFormatPatternField extends _DateFormatField {
   /// e.g. 'yyyy' for a four-digit year. This hard-codes all the pattern
   /// characters that pertain to dates. The remaining characters, 'ahHkKms' are
   /// all time-related. See e.g. [formatField]
+  @override
   bool get forDate => _forDate ??= 'cdDEGLMQvyZz'.contains(pattern[0]);
 
   /// Parse a field representing part of a date pattern. Note that we do not

--- a/lib/src/intl/micro_money.dart
+++ b/lib/src/intl/micro_money.dart
@@ -70,6 +70,7 @@ class _MicroMoney implements MicroMoney {
 
   int toInt() => _integerPart.toInt();
 
+  @override
   String toString() {
     var beforeDecimal = '$_integerPart';
     var decimalPart = '';

--- a/lib/src/intl/number_format.dart
+++ b/lib/src/intl/number_format.dart
@@ -925,6 +925,7 @@ class NumberFormat {
     _finalGroupingSize = 0;
   }
 
+  @override
   String toString() => 'NumberFormat($_locale, $_pattern)';
 }
 

--- a/lib/src/intl_helpers.dart
+++ b/lib/src/intl_helpers.dart
@@ -53,6 +53,7 @@ class UninitializedLocaleData<F> implements MessageLookup {
   String get _uninitializedMessages =>
       (_badMessages.toSet().toList()..sort()).join('\n    ');
 
+  @override
   String? lookupMessage(String? messageText, String? locale, String? name,
       List<Object>? args, String? meaning,
       {MessageIfAbsent? ifAbsent}) {
@@ -81,6 +82,7 @@ class UninitializedLocaleData<F> implements MessageLookup {
         ', call $message.');
   }
 
+  @override
   void addLocale(String localeName, Function findLocale) => _throwException();
 }
 
@@ -94,6 +96,7 @@ abstract class MessageLookup {
 class LocaleDataException implements Exception {
   final String message;
   LocaleDataException(this.message);
+  @override
   String toString() => 'LocaleDataException: $message';
 }
 

--- a/lib/src/locale/locale_implementation.dart
+++ b/lib/src/locale/locale_implementation.dart
@@ -137,6 +137,7 @@ class LocaleImplementation extends Locale {
   /// (deprecated tags have been replaced), but not necessarily valid (the
   /// language might not exist) because the list of valid languages changes with
   /// time.
+  @override
   final String languageCode;
 
   /// The script subtag of the Locale Identifier, null if absent.
@@ -145,6 +146,7 @@ class LocaleImplementation extends Locale {
   /// (deprecated tags have been replaced), but not necessarily valid (the
   /// script might not exist) because the list of valid scripts changes with
   /// time.
+  @override
   final String? scriptCode;
 
   /// The region subtag of the Locale Identifier, null if absent.
@@ -153,6 +155,7 @@ class LocaleImplementation extends Locale {
   /// (deprecated tags have been replaced), but not necessarily valid (the
   /// region might not exist) because the list of valid regions changes with
   /// time.
+  @override
   final String? countryCode;
 
   /// Iterable of variant subtags, zero-length iterable if variants are absent.
@@ -161,6 +164,7 @@ class LocaleImplementation extends Locale {
   /// (sorted alphabetically and deprecated tags have been replaced) but not
   /// necessarily valid (variants might not exist) because the list of variants
   /// changes with time.
+  @override
   final Iterable<String> variants;
 
   /// Locale extensions, null if the locale has no extensions.
@@ -171,6 +175,7 @@ class LocaleImplementation extends Locale {
   String? _languageTag;
 
   /// Returns the canonical Unicode BCP47 Locale Identifier for this locale.
+  @override
   String toLanguageTag() {
     if (_languageTag == null) {
       final out = [languageCode];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,4 +17,5 @@ dev_dependencies:
   ffi: ^1.0.0
   fixnum: ^1.0.0
   js: ^0.6.3
+  lints: ^1.0.0
   test: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,12 @@ environment:
 
 dependencies:
   clock: ^1.1.0
+  meta: ^1.0.2
   path: ^1.8.0
 
 dev_dependencies:
   ffi: ^1.0.0
   fixnum: ^1.0.0
   js: ^0.6.3
-  lints: ^1.0.0
+  lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0

--- a/test/date_time_format_test_core.dart
+++ b/test/date_time_format_test_core.dart
@@ -11,6 +11,7 @@ library date_time_format_tests;
 import 'package:clock/clock.dart';
 import 'package:intl/intl.dart';
 import 'package:test/test.dart';
+
 import 'date_time_format_test_data.dart';
 
 var formatsToTest = const [

--- a/test/more_compact_number_test_data.dart
+++ b/test/more_compact_number_test_data.dart
@@ -33,6 +33,7 @@ class CompactRoundingTestCase {
   int? maximumSignificantDigits;
   int? minimumSignificantDigits;
 
+  @override
   String toString() => "CompactRoundingTestCase for $number, "
       "maxIntDig: $maximumIntegerDigits, "
       "minIntDig: $minimumIntegerDigits, "

--- a/test/number_format_compact_icu_test.dart
+++ b/test/number_format_compact_icu_test.dart
@@ -77,21 +77,21 @@ void _validateFancy(more_testdata.CompactRoundingTestCase t) {
   var locale = 'en';
   var skel = 'compact-short';
   if (t.minimumIntegerDigits != null) {
-    skel += ' integer-width/+' + '0' * t.minimumIntegerDigits!;
+    skel += ' integer-width/+${'0' * t.minimumIntegerDigits!}';
   }
   if (t.maximumSignificantDigits != null) {
-    skel += ' ' + '@' * t.maximumSignificantDigits!;
+    skel += ' ${'@' * t.maximumSignificantDigits!}';
     if (t.minimumSignificantDigits != t.maximumSignificantDigits) {
       // Pattern doesn't support min/max significant digits. Ignore.
       return;
     }
   }
   if (t.minimumFractionDigits != null) {
-    skel += ' .' + '0' * t.minimumFractionDigits!;
+    skel += ' .${'0' * t.minimumFractionDigits!}';
     var maxFD = t.maximumFractionDigits ?? 3;
     skel += '#' * (maxFD - t.minimumFractionDigits!);
   } else if (t.maximumFractionDigits != null) {
-    skel += ' .' + '#' * t.maximumFractionDigits!;
+    skel += ' .${'#' * t.maximumFractionDigits!}';
   }
   test(t.toString(), () {
     expect(_formatWithUnumf(locale, skel, t.number), t.expected,

--- a/test/number_format_compact_icu_test.dart
+++ b/test/number_format_compact_icu_test.dart
@@ -4,10 +4,12 @@
 /// testing the package:intl implementation, they only help verify consistent
 /// behaviour across platforms.
 
-@TestOn("!browser")
+// ignore_for_file: non_constant_identifier_names
+
+@TestOn('!browser')
 @Tags(['ffi'])
-@Skip(
-    "currently failing (see issue https://github.com/dart-lang/intl/issues/240)")
+@Skip('currently failing (see https://github.com/dart-lang/intl/issues/240)')
+
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:test/test.dart';

--- a/test/number_format_compact_test.dart
+++ b/test/number_format_compact_test.dart
@@ -111,7 +111,7 @@ void main() {
   parsingTestCases.forEach(_validateParsing);
 
   test("Patterns are consistent across locales", () {
-    var checkPatterns = (Map<int, Map<String, String>> patterns) {
+    checkPatterns(Map<int, Map<String, String>> patterns) {
       expect(patterns, isNotEmpty);
       // Check patterns are iterable in order.
       var lastExp = -1;
@@ -123,7 +123,7 @@ void main() {
         var patternMap = entries.value;
         expect(patternMap, isNotEmpty);
       }
-    };
+    }
 
     patterns.compactNumberSymbols.forEach((locale, patterns) {
       checkPatterns(patterns.COMPACT_DECIMAL_SHORT_PATTERN);

--- a/test/timezone_test_core.dart
+++ b/test/timezone_test_core.dart
@@ -25,9 +25,9 @@ void testTimezone(String timezoneName, {int? expectedUtcOffset}) {
       packageDir == null ? packageRelative : '$packageDir/$packageRelative';
 
   test('Run tests in $timezoneName time zone', () async {
-    var args = <String>[]
-      ..addAll(vmArgs)
-      ..add(fileToSpawn);
+    var args = <String>[...vmArgs, fileToSpawn]
+      
+      ;
     var environment = <String, String>{'TZ': timezoneName};
     if (expectedUtcOffset != null) {
       environment['EXPECTED_TZ_OFFSET_FOR_TEST'] = '$expectedUtcOffset';

--- a/test/timezone_test_core.dart
+++ b/test/timezone_test_core.dart
@@ -25,9 +25,7 @@ void testTimezone(String timezoneName, {int? expectedUtcOffset}) {
       packageDir == null ? packageRelative : '$packageDir/$packageRelative';
 
   test('Run tests in $timezoneName time zone', () async {
-    var args = <String>[...vmArgs, fileToSpawn]
-      
-      ;
+    var args = <String>[...vmArgs, fileToSpawn];
     var environment = <String, String>{'TZ': timezoneName};
     if (expectedUtcOffset != null) {
       environment['EXPECTED_TZ_OFFSET_FOR_TEST'] = '$expectedUtcOffset';

--- a/tool/generate_locale_data_files.dart
+++ b/tool/generate_locale_data_files.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 /// A utility program to take locale data represented as a Dart map whose keys
 /// are locale names and write it into individual JSON files named by locale.
@@ -12,13 +11,15 @@
 /// which is sourced by the date_symbol_data... files.
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/date_time_patterns.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
+
 import '../test/data_directory.dart' as test;
 
-String dataDirectoryOverride;
+String? dataDirectoryOverride;
 
 String get dataDirectory => dataDirectoryOverride ?? test.dataDirectory;
 
@@ -41,16 +42,12 @@ void writeLocaleList() {
       'code is governed by a\n// BSD-style license that can be found in the'
       ' LICENSE file.\n\n'
       '/// Hard-coded list of all available locales for dates.\n');
-  output.write('final availableLocalesForDateFormatting = const [');
+  output.writeln('final availableLocalesForDateFormatting = const [');
   var allLocales = DateFormat.allLocalesWithSymbols();
   for (var locale in allLocales) {
-    output.write("'$locale'");
-    if (locale == allLocales.last) {
-      output.write('];');
-    } else {
-      output.write(',\n    ');
-    }
+    output.writeln("  '$locale',");
   }
+  output.writeln('];');
   output.close();
 }
 


### PR DESCRIPTION
- upgrade to package:lints 1.0
- remove an analysis exclude of a test file
- upgrade to package:lints 2.0
- migrate the last file to null safety

This PR keeps two public APIs that appear to only be intended to be public for testing; they were found via the `library_private_types_in_public_api` lint - the APIs are returning private types. They're now marked as visible for testing and deprecated as well.
