### PR TITLE
Support runtime interception setting text

### DIFF
--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -173,8 +173,31 @@ class Intl {
     return _lookupMessage(messageText, locale, name, args, meaning)!;
   }
 
+
+  ///define a text interceptor
+  static String? Function(String? messageText, String? locale, String? name,
+      List<Object>? args, String? meaning)? _textInterceptor;
+
+  ///If a text interceptor is set, then get the text content you set first by this function；
+  ///e.g. set some text incrementally by the server
+  ///
+  ///如果设置了文本拦截器，那么优先获取你设置的文本内容,
+  ///例如通过服务器增量设置一些文案
+  static void setTextInterceptor(
+      String Function(String? messageText, String? locale, String? name,
+          List<Object>? args, String? meaning)
+      textInterceptor) {
+    Intl._textInterceptor = textInterceptor;
+  }
+
   static String? _lookupMessage(String? messageText, String? locale,
       String? name, List<Object>? args, String? meaning) {
+    if (_textInterceptor != null) {
+      var result = _textInterceptor!(messageText, locale, name, args, meaning);
+      if (result != "") {
+        return result;
+      }
+    }
     return helpers.messageLookup
         .lookupMessage(messageText, locale, name, args, meaning);
   }


### PR DESCRIPTION
Support post-setting of copywriting, such as setting problems in the later period such as holidays; if you find that the copywriting setting is wrong, you can incrementally replace it later

支持后期设置文案，例如后期在节假日等设置问题；发现文案设置错误后可以在后期增量替换
```dart
  static void init(String package) async {
    String key = "language.$package";
    var body = {"key": key};
    //first get by local storage
    //现获取本地的
    await getStorage(key).then((value) {
      if (value != null) {
        setConfig(value as Map<String, dynamic>);
      }
    });
    //然后使用在线的
    // then get from server
    HttpUtils.get(Api.kvConfig, parameters: body, success: (t) {
      var result = t as Map<String, dynamic>;
      var data = json.decode(result["val"]);
      if (data != null) {
        setConfig(data as Map<String, dynamic>);
        //set local storage
        setStorage(key, data);
      }

      Log.i('get language from server success $language success');
      
    }, fail: (code, t) {
      Log.e('get language  from server  $language err');
    });
  }

  static void setConfig(Map<String, dynamic> data) {
    Intl.setTextInterceptor((messageText, locale, name, args, meaning) {
      if (data.containsKey(name)) {
        return data[name]!;
      }
      return "";
    });
  }

```