### PR TITLE
Support runtime interception setting text

### DIFF
--- a/lib/intl.dart
+++ b/lib/intl.dart
@@ -173,8 +173,30 @@ class Intl {
     return _lookupMessage(messageText, locale, name, args, meaning)!;
   }
 
+  ///define a text interceptor
+  static String? Function(String? messageText, String? locale, String? name,
+      List<Object>? args, String? meaning)? _textInterceptor;
+
+  ///If a text interceptor is set, then get the text content you set first by this function；
+  ///e.g. set some text incrementally by the server
+  ///
+  ///如果设置了文本拦截器，那么优先获取你设置的文本内容,
+  ///例如通过服务器增量设置一些文案
+  static void setTextInterceptor(
+      String Function(String? messageText, String? locale, String? name,
+          List<Object>? args, String? meaning)
+      textInterceptor) {
+    Intl._textInterceptor = textInterceptor;
+  }
+
   static String? _lookupMessage(String? messageText, String? locale,
       String? name, List<Object>? args, String? meaning) {
+    if (_textInterceptor != null) {
+      var result = _textInterceptor!(messageText, locale, name, args, meaning);
+      if (result != "") {
+        return result;
+      }
+    }
     return helpers.messageLookup
         .lookupMessage(messageText, locale, name, args, meaning);
   }


### PR DESCRIPTION
Support post-setting of copywriting, such as setting problems in the later period such as holidays; if you find that the copywriting setting is wrong, you can incrementally replace it later

支持后期设置文案，例如后期在节假日等设置问题；发现文案设置错误后可以在后期增量替换


for example:

```dart
 static void init() async {
   // get local storage first
   // then config from server
    HttpUtils.get(Api.kvConfig, parameters:{}, success: (t) {
      var result = t as Map<String, dynamic>;
      var data = json.decode(result["val"]);
      if (data != null) {
        Intl.setTextInterceptor((messageText, locale, name, args, meaning) {
          if (data.containsKey(name)) {
            return data[name]!;
          }
          return "";
        });
      
        //setLocalStorage(key, data);
      }
      Log.i('get language from server $language success');
    }, fail: (code, t) {
      Log.e('get language from server error $language err');
    });
  

  }

```


