### PR TITLE
Fix rounding number issue on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ To format a number, create a NumberFormat instance.
 ```dart
 var f = NumberFormat('###.0#', 'en_US');
 print(f.format(12.345));
-  ==> 12.34
+  ==> 12.35
 ```
 
 The locale parameter is optional. If omitted, then it will use the


### PR DESCRIPTION
Fix rounding number issue on README.md

current, following test code fails.
```
    final f = NumberFormat('###.0#', 'en_US');
    expect(f.format(12.345), '12.34'); -> fails
```