### PR TITLE
Remove an unnecessary sort

### DIFF
--- a/lib/src/intl/date_format_field.dart
+++ b/lib/src/intl/date_format_field.dart
@@ -450,9 +450,10 @@ class _DateFormatPatternField extends _DateFormatField {
     var results = IntlStream(possibilities)
         .findIndexes((each) => input.peek(each.length) == each);
     if (results.isEmpty) throwFormatException(input);
-    results.sort(
-        (a, b) => possibilities[a].length.compareTo(possibilities[b].length));
-    var longestResult = results.last;
+    var longestResult = results.first;
+    for (var result in results.skip(1)) {
+      if (result.length >= longestResult.length) longestResult = result;
+    }
     input.read(possibilities[longestResult].length);
     return longestResult;
   }

--- a/lib/src/intl/date_format_field.dart
+++ b/lib/src/intl/date_format_field.dart
@@ -452,7 +452,9 @@ class _DateFormatPatternField extends _DateFormatField {
     if (results.isEmpty) throwFormatException(input);
     var longestResult = results.first;
     for (var result in results.skip(1)) {
-      if (result.length >= longestResult.length) longestResult = result;
+      if (possibilities[result].length >= possibilities[longestResult].length) {
+        longestResult = result;
+      }
     }
     input.read(possibilities[longestResult].length);
     return longestResult;


### PR DESCRIPTION
Iterate once to find the list instead of sorting the entire list and taking the last value.