### PR TITLE
Cleanup of `var this.`, dynamic parameters, and more

### DIFF
--- a/lib/message_format.dart
+++ b/lib/message_format.dart
@@ -523,8 +523,7 @@ class MessageFormat {
   /// A regular expression to parse the select block.
   ///
   /// It extracts the argument index.
-  static final RegExp _selectBlockRe =
-      RegExp(r'^\s*(\w+)\s*,\s*select\s*,');
+  static final RegExp _selectBlockRe = RegExp(r'^\s*(\w+)\s*,\s*select\s*,');
 
   /// Detects the block type of the [pattern].
   _BlockType _parseBlockType(String pattern) {

--- a/lib/message_format.dart
+++ b/lib/message_format.dart
@@ -815,5 +815,5 @@ class _ElementTypeAndVal extends _TypeAndVal<_ElementType, String> {
 enum _BlockType { plural, ordinal, select, simple, string, unknown }
 
 class _BlockTypeAndVal extends _TypeAndVal<_BlockType, Object> {
-  _BlockTypeAndVal(_BlockType type, Object value) : super(type, value);up 
+  _BlockTypeAndVal(_BlockType type, Object value) : super(type, value);
 }

--- a/lib/message_format.dart
+++ b/lib/message_format.dart
@@ -136,10 +136,10 @@ class MessageFormat {
   static const String _other = 'other';
 
   /// Regular expression for looking for string literals.
-  static final RegExp _regexLiteral = RegExp("'([{}#].*?)'");
+  static final RegExp _regexLiteral = RegExp(r"'([{}#].*?)'");
 
-  /// Regular expression for looking for '' in the message.
-  static final RegExp _regexDoubleApostrophe = RegExp("''");
+  /// Pattern for looking for '' in the message.
+  static final Pattern _patternDoubleApostrophe = "''";
 
   /// Create a MessageFormat for the ICU message string [pattern].
   /// It does parameter substitutions in a locale-aware way.
@@ -442,14 +442,14 @@ class MessageFormat {
 
     // First replace '' with single quote placeholder since they can be found
     // inside other literals.
-    pattern = pattern.replaceAllMapped(_regexDoubleApostrophe, (match) {
+    pattern = pattern.replaceAllMapped(_patternDoubleApostrophe, (match) {
       literals.add("'");
       return buildPlaceholder(literals);
     });
 
     pattern = pattern.replaceAllMapped(_regexLiteral, (match) {
       // match, text
-      var text = match.group(1)!;
+      var text = match[1]!;
       literals.add(text);
       return buildPlaceholder(literals);
     });
@@ -463,7 +463,7 @@ class MessageFormat {
     var braceStack = Queue<String>();
     var results = Queue<_ElementTypeAndVal>();
 
-    var braces = RegExp('[{}]');
+    var braces = RegExp(r'[{}]');
 
     Match match;
     for (match in braces.allMatches(pattern)) {
@@ -512,19 +512,19 @@ class MessageFormat {
   ///
   /// It extracts the argument index and offset (if any).
   static final RegExp _pluralBlockRe =
-      RegExp('^\\s*(\\w+)\\s*,\\s*plural\\s*,(?:\\s*offset:(\\d+))?');
+      RegExp(r'^\s*(\w+)\s*,\s*plural\s*,(?:\s*offset:(\d+))?');
 
   /// A regular expression to parse the ordinal block.
   ///
   /// It extracts the argument index.
   static final RegExp _ordinalBlockRe =
-      RegExp('^\\s*(\\w+)\\s*,\\s*selectordinal\\s*,');
+      RegExp(r'^\s*(\w+)\s*,\s*selectordinal\s*,');
 
   /// A regular expression to parse the select block.
   ///
   /// It extracts the argument index.
   static final RegExp _selectBlockRe =
-      RegExp('^\\s*(\\w+)\\s*,\\s*select\\s*,');
+      RegExp(r'^\s*(\w+)\s*,\s*select\s*,');
 
   /// Detects the block type of the [pattern].
   _BlockType _parseBlockType(String pattern) {
@@ -540,7 +540,7 @@ class MessageFormat {
       return _BlockType.select;
     }
 
-    if (RegExp('^\\s*\\w+\\s*').hasMatch(pattern)) {
+    if (RegExp(r'^\s*\w').hasMatch(pattern)) {
       return _BlockType.simple;
     }
 
@@ -599,7 +599,7 @@ class MessageFormat {
     var replaceRegex = _selectBlockRe;
     pattern = pattern.replaceFirstMapped(replaceRegex, (match) {
       // string, name
-      argumentName = match.group(1)!;
+      argumentName = match[1]!;
       return '';
     });
     var result = <String, Object>{'argumentName': argumentName};
@@ -622,7 +622,7 @@ class MessageFormat {
       } else {
         _checkAndThrow(false, 'Expected block type.');
       }
-      result[key.replaceAll(RegExp('\\s'), '')] = value!;
+      result[key.replaceAll(RegExp(r'\s+'), '')] = value!;
       pos++;
     }
 
@@ -641,9 +641,9 @@ class MessageFormat {
     var replaceRegex = _pluralBlockRe;
     pattern = pattern.replaceFirstMapped(replaceRegex, (match) {
       // string, name, offset
-      argumentName = match.group(1)!;
-      if (_isDef(match.group(2))) {
-        argumentOffset = int.parse(match.group(2)!);
+      argumentName = match[1]!;
+      if (_isDef(match[2])) {
+        argumentOffset = int.parse(match[2]!);
       }
       return '';
     });
@@ -671,8 +671,8 @@ class MessageFormat {
       } else {
         _checkAndThrow(false, 'Expected block type.');
       }
-      key = key.replaceFirstMapped(RegExp('\\s*(?:=)?(\\w+)\\s*'), (match) {
-        return match.group(1).toString();
+      key = key.replaceFirstMapped(RegExp(r'\s*=?(\w+)\s*'), (match) {
+        return match[1].toString();
       });
       result[key] = value!;
       pos++;
@@ -704,7 +704,7 @@ class MessageFormat {
     var replaceRegex = _ordinalBlockRe;
     pattern = pattern.replaceFirstMapped(replaceRegex, (match) {
       // string, name
-      argumentName = match.group(1)!;
+      argumentName = match[1]!;
       return '';
     });
 
@@ -728,8 +728,8 @@ class MessageFormat {
       } else {
         _checkAndThrow(false, 'Expected block type.');
       }
-      key = key.replaceFirstMapped(RegExp('\\s*(?:=)?(\\w+)\\s*'), (match) {
-        return match.group(1).toString();
+      key = key.replaceFirstMapped(RegExp(r'\s*=?(\w+)\s*'), (match) {
+        return match[1].toString();
       });
       result[key] = value!;
       pos++;
@@ -760,7 +760,7 @@ bool _isDef(Object? obj) {
   return obj != null;
 }
 
-// Closure calls assert, which actually ends up with an exception on can catch.
+// Closure calls assert, which actually ends up with an exception one can catch.
 // In Dart assert is only for debug, so I am using this small wrapper method.
 void _checkAndThrow(bool condition, String message) {
   if (!condition) {
@@ -796,7 +796,7 @@ class _TypeAndVal<T, V> {
   final T _type;
   final V _value;
 
-  _TypeAndVal(var this._type, var this._value);
+  _TypeAndVal(this._type, this._value);
 
   @override
   String toString() {
@@ -808,12 +808,12 @@ class _TypeAndVal<T, V> {
 enum _ElementType { string, block }
 
 class _ElementTypeAndVal extends _TypeAndVal<_ElementType, String> {
-  _ElementTypeAndVal(var type, var value) : super(type, value);
+  _ElementTypeAndVal(_ElementType type, String value) : super(type, value);
 }
 
 /// Block type.
 enum _BlockType { plural, ordinal, select, simple, string, unknown }
 
 class _BlockTypeAndVal extends _TypeAndVal<_BlockType, Object> {
-  _BlockTypeAndVal(var type, var value) : super(type, value);
+  _BlockTypeAndVal(_BlockType type, Object value) : super(type, value);up 
 }


### PR DESCRIPTION
Clean-up in `message_format.dart`.
Removed the `var` in front of constructor initializing parameters. It does nothing. While I was here:
* Added types on the subtype constructor parameters, avoiding implicit downcasts from dynamic.
* Cleaned up RegExps (mostly adding `r` in front to avoid double backslashes, a few simplifications).
* Changed `Match.group` to using the preferred `[...]` syntax.