### PR TITLE
Simplify zero charcode offset code

### DIFF
--- a/lib/src/intl/intl_stream.dart
+++ b/lib/src/intl/intl_stream.dart
@@ -51,13 +51,8 @@ class IntlStream {
     if (string == null || string.isEmpty) return null;
     read(string.length);
     if (zeroDigit != constants.asciiZeroCodeUnit) {
-      // Trying to optimize this, as it might get called a lot.
-      var oldDigits = string.codeUnits;
-      var newDigits = List<int>.filled(string.length, 0);
-      for (var i = 0; i < string.length; i++) {
-        newDigits[i] = oldDigits[i] - zeroDigit + constants.asciiZeroCodeUnit;
-      }
-      string = String.fromCharCodes(newDigits);
+      string = String.fromCharCodes(string.codeUnits
+          .map((c) => c - zeroDigit + constants.asciiZeroCodeUnit));
     }
     return int.parse(string);
   }


### PR DESCRIPTION
Use `.map` instead of eagerly filling a list. The result is only iterated once. We expect all of these strings to be relatively short in typical cases, the numeric parts of Date strings don't have many digits.