### PR TITLE
Remove unimplemented timezone functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.18.1
 
 * Update ruble sign and update corresponding test
+* Remove unimplemented timezone functionality
 
 ## 0.18.0
  * Add support for `minimumSignificantDigits` / `maximumSignificantDigits` in

--- a/lib/src/intl/date_format_field.dart
+++ b/lib/src/intl/date_format_field.dart
@@ -386,14 +386,8 @@ class _DateFormatPatternField extends _DateFormatField {
         return formatFractionalSeconds(date);
       case 's':
         return formatSeconds(date);
-      case 'v':
-        return formatTimeZoneId(date);
       case 'y':
         return formatYear(date);
-      case 'z':
-        return formatTimeZone(date);
-      case 'Z':
-        return formatTimeZoneRFC(date);
       default:
         return '';
     }
@@ -684,19 +678,6 @@ class _DateFormatPatternField extends _DateFormatField {
 
   String formatSeconds(DateTime date) {
     return padTo(width, date.second);
-  }
-
-  String formatTimeZoneId(DateTime date) {
-    // TODO(alanknight): implement time zone support
-    throw UnimplementedError();
-  }
-
-  String formatTimeZone(DateTime date) {
-    throw UnimplementedError();
-  }
-
-  String formatTimeZoneRFC(DateTime date) {
-    throw UnimplementedError();
   }
 
   /// Return a string representation of the object padded to the left with


### PR DESCRIPTION
As they throw `UnimplementedExceptions` and distract from using [package:timezone](https://pub.dev/packages/timezone), remove the methods.